### PR TITLE
allow receive jwt extractor factory from options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The JWT authentication strategy is constructed as follows:
 
 - `jwtFromRequest` (Optional)
 
+  This value can be set according [passport-jwt](http://www.passportjs.org/packages/passport-jwt/#extracting-the-jwt-from-the-request)
   if this options is not used, passport-keycloak-bearer will obtain jwt from http header Auth as a Bearer token.
 
 - `jsonWebTokenOptions` (Optional)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ The JWT authentication strategy is constructed as follows:
 
   If true do not validate the expiration of the token.
 
+- `jwtFromRequest` (Optional)
+
+  if this options is not used, passport-keycloak-bearer will obtain jwt from http header Auth as a Bearer token.
+
 - `jsonWebTokenOptions` (Optional)
 
   passport-keycloak-bearer is verifying the token using [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken).

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -13,7 +13,8 @@ class KeycloakBearerStrategy extends Strategy {
   constructor (options, verify) {
     verifyOptions(options)
     const opts = setDefaults(options)
-    opts.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken()
+    if (!opts.jwtFromRequest)
+      opts.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken()
     const oidcManager = new OIDCManager(opts.url, opts.realm, opts.log)
     opts.secretOrKeyProvider = (req, token, done) => {
       oidcManager


### PR DESCRIPTION
This PR is intended to allow JWTs obtained by means other than Authorization HTTP Header.