### PR TITLE
Filtering only RSA Keys

### DIFF
--- a/src/oidcMatadata.js
+++ b/src/oidcMatadata.js
@@ -13,10 +13,11 @@ class OIDCMatadata {
   }
 
   getKeysFromResponse(body) {
-    if (!body.keys || body.keys.length === 0) {
+    const rsaKeys = body.keys && body.keys.filter((key) => key.kty === "RSA");
+    if (!rsaKeys || rsaKeys.length === 0) {
       throw new Error('We got no AAD signing Keys');
     }
-    return body.keys.map((key) => ({
+    return rsaKeys.map((key) => ({
       ...key,
       pemKey: rsaPublicKeyPem(key.n, key.e),
     }));


### PR DESCRIPTION
We had a situation where a ecdsa-generated keystore was added to keycloak's to keycloak Keys, and this key was returned in /auth/realms/{realm}/protocol/openid-connect/certs endpoint. In this case, due to not existing "n" and "e" properties, we were facing this error:

Error: Cannot get AAD signing Keys from url https://*********/auth/realms/****/protocol/openid-connect/certs. We got a The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined
    at OIDCMatadata.getPemKeys (/app/node_modules/passport-keycloak-bearer/src/oidcMatadata.js:53:13)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async OIDCMatadata.pemKeyFromToken (/app/node_modules/passport-keycloak-bearer/src/oidcMatadata.js:64:18)

This is because Buffer.from in first line of rsaPublicKeyPem method was receiving undefined.

So, this proposed change avoid this situation, filtering only RSA keys.